### PR TITLE
[fix]: remove ternary operator + claimLockFee2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ bun.lockb
 
 ts-client/dist/
 ts-client/package-lock.json
-
+ts-client/scripts
 ts-client/.env
 
 commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - remove ternary operator in `claimLockFee` function
+- added `claimLockFee2` function to claim lock fees without tempWSolAcc
 
 ## @meteora-ag/dynamic-amm-sdk [1.3.8] - PR[#218](https://github.com/MeteoraAg/dynamic-amm-sdk/pull/218)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dynamic-amm-sdk [1.3.9] - PR[#219](https://github.com/MeteoraAg/dynamic-amm-sdk/pull/218)
+
+### Changed
+
+- remove ternary operator in `claimLockFee` function
+
 ## @meteora-ag/dynamic-amm-sdk [1.3.8] - PR[#218](https://github.com/MeteoraAg/dynamic-amm-sdk/pull/218)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## @meteora-ag/dynamic-amm-sdk [1.3.9] - PR[#219](https://github.com/MeteoraAg/dynamic-amm-sdk/pull/218)
+## @meteora-ag/dynamic-amm-sdk [1.3.9] - PR[#222](https://github.com/MeteoraAg/dynamic-amm-sdk/pull/222)
 
 ### Changed
 

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -41,6 +41,7 @@
     "mocha": "^10.0.0",
     "ts-jest": "^28.0.2",
     "ts-mocha": "^10.0.0",
+    "tsx": "^4.20.3",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dynamic-amm-sdk",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Meteora Dynamic Amm SDK is a typescript library that allows you to interact with Meteora's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -2933,14 +2933,24 @@ export default class AmmImpl implements AmmImplementation {
     let tx: Transaction;
 
     if (isTokenAOrBNative) {
-      const tempWSol = receiver && !receiver.equals(owner) ? tempWSolAcc : owner;
+      let tempWSol: PublicKey;
+
+      if (receiver && !receiver.equals(owner)) {
+        if (!tempWSolAcc) {
+          throw new Error('tempWSolAcc is required when receiver is different from owner for native token pools');
+        }
+        tempWSol = tempWSolAcc;
+      } else {
+        tempWSol = owner;
+      }
+
       const feeReceiver = receiver ? receiver : owner;
 
       const result = await this.claimWithQuoteMintSol({
         owner,
         payer,
         receiver: feeReceiver,
-        tempWSolAcc: tempWSol!,
+        tempWSolAcc: tempWSol,
         lockEscrowPK,
       });
 


### PR DESCRIPTION
similar to claimPositionFee2 in damm v2 sdk and claimPartnerTradingFee2 in dbc sdk:

https://github.com/MeteoraAg/damm-v2-sdk/blob/328f6e6780ffe208e4bb5bf1b1cf3b2b0183fc1e/src/CpAmm.ts#L2790

https://github.com/MeteoraAg/dynamic-bonding-curve-sdk/blob/a9466fa0061473160c4369b09cc6fc1766df0b99/packages/dynamic-bonding-curve/src/services/partner.ts#L362